### PR TITLE
Add support for jinja2 versions >= 3.1.0

### DIFF
--- a/django_sequential_pagination/templatetags/pagination.py
+++ b/django_sequential_pagination/templatetags/pagination.py
@@ -20,7 +20,12 @@ try:
 except ImportError:
 	pass
 else:
-	jinja2.contextfunction(paginate)
+	if jinja2.__version__ < '3.0.0':
+		contextfunction = jinja2.contextfunction
+	else:
+		contextfunction = jinja2.pass_context
+
+	contextfunction(paginate)
 
 try:
 	from django_jinja import library


### PR DESCRIPTION
Fixes: https://github.com/IlyaSemenov/django-sequential-pagination/issues/1

In jinja2 3.1.0, the contextfunction was removed and replaced with pass_context.